### PR TITLE
Various updates to vADC pack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,35 @@
 # Change Log
 
+# 0.3.0
+
+- vtm_add_pool now only sets nodes, unless you provide the optional params
+for algorithm, monitors, and session persistence.
+
+- You can now parse JSON or YAML strings in an `extra` parameter to apply
+addition configuration when creating objects. This can be used with:
+  - vtm_add_pool
+  - vtm_add_vserver
+  - vtm_add_tip
+
+- New action to locate a running vTM when provided with a list of vTMs or
+  a Cluster ID.
+
+- Example vADC webhook rule included, and a python script for calling the hook
+  from the vTM Alerting framework. Script: `files/st2-trigger.py`
+  - New Action to upload webhook: `vadc.vtm_add_webhook_action`
+
+- Added support for vTMs as old as 9.3.
+  - Services Director will try universal license and fall back to Legacy FLA
+
+- Added support for list/create/restore/delete backups on vTM 11.0 and above
+  - Restore requires Services Director 2.6, if you are proxying
+
+- We now detect the latest version of the API available on the BSD/VTM and use it.
+
 # 0.2.0
 
 - Moved `config.yaml` to `vadc.yaml.example`
 
 # 0.1.0
 
-- First release 
+- First release

--- a/README.md
+++ b/README.md
@@ -219,6 +219,27 @@ _Operations_
     You must provide the vtm, name, and a list of nodes. By default we
     drain nodes, but you can pass drain=false to undrain them.
 
+  * vtm\_set\_pool\_nodes
+    Set nodes in pool by providing lists of active, draining, and
+    disabled nodes.
+
+  * vtm\_enable\_ssl\_offload
+    Enable SSL Offload on a VTM Virtual Server. You must provide the 
+    vserver, and certificate name, and optionally whether to inject the
+    X-Forwarded-Protocol, and additional SSL Headers.
+    There is also a _disable_ action.
+
+  * vtm\_enable\_ssl\_encryption
+    Enable SSL Encryption on a pool. You must provide the name of the pool.
+    If you want vTM to verify the certificate chain of the server, then set
+    verify to true.
+    There is also a _disable_ action.
+
+  * vtm\_add\_webhook\_action
+    Uploads the webhook action script to the vTM. You must provide the st2
+    API Key, and WebHook URI for the action to call. The action can be 
+    associated with an existing event on the vTM, if you provide its name.
+
   * vtm\_get\_pool\_nodes  
     Retrieve a list of nodes from the given pool. You must provide the
     vtm and the name of the pool.
@@ -227,6 +248,29 @@ _Operations_
     Enabled or disable a Maintenance mode TrafficScript rule.  
     You must provide the vtm and vserver name, default is to enable the
     maintenance rule, and the default rule name is maintenance.
+
+_Backups_
+
+  * vtm\_list\_backups
+    Get a list of Backups from the provided vTM
+
+  * vtm\_create\_backup
+    Create a new BackUp on the vTM.
+
+  * vtm\_delete\_backup
+    Remove a backup from the vTM.
+
+  * vtm\_add\_backup
+    Upload a Backup to the vTM ready for restoration. You must provide the
+    filename in the `tarball` parameter.
+
+  * vtm\_get\_backup
+    Download a backup from the vTM. This will be downloaded to the local
+    file system in `outdir`. The name of the file will be returned in the
+    result.
+
+  * vtm\_restore\_backup
+    Restore a backup to the vTM.
 
 _Chains and workflows_
 

--- a/actions/bsd_get_active_vtm.py
+++ b/actions/bsd_get_active_vtm.py
@@ -1,0 +1,14 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Bsd
+
+
+class BsdGetActiveVtm(Action):
+
+    def run(self, vtms, cluster):
+        bsd = Bsd(self.config, self.logger)
+        result = bsd.get_active_vtm(vtms, cluster)
+        if result is None:
+            return (False, result)
+        return (True, result)

--- a/actions/bsd_get_active_vtm.yaml
+++ b/actions/bsd_get_active_vtm.yaml
@@ -1,0 +1,14 @@
+description: 'Service Director - Find an Active vTM in a Cluster/List'
+enabled: true
+entry_point: bsd_get_active_vtm.py
+name: bsd_get_active_vtm
+runner_type: "python-script"
+parameters:
+  vtms:
+    description: "List of vTMs to Check"
+    type: array
+    required: false
+  cluster:
+    description: "The Cluster ID/Tag. Cluster trumps vtms list if you provide both."
+    type: string
+    required: false

--- a/actions/bsd_get_errors.py
+++ b/actions/bsd_get_errors.py
@@ -8,5 +8,5 @@ class BsdGetErrors(Action):
 
     def run(self, stringify):
         bsd = Bsd(self.config, self.logger)
-        result = bsd.getErrors(stringify)
-        return result
+        result = bsd.get_errors(stringify)
+        return (True, result)

--- a/actions/bsd_get_status.py
+++ b/actions/bsd_get_status.py
@@ -9,5 +9,5 @@ class BsdGetStatus(Action):
     def run(self, vtm, stringify):
 
         bsd = Bsd(self.config, self.logger)
-        result = bsd.getStatus(vtm, stringify)
-        return result
+        result = bsd.get_status(vtm, stringify)
+        return (True, result)

--- a/actions/bsd_get_vtm_bandwidth.py
+++ b/actions/bsd_get_vtm_bandwidth.py
@@ -9,5 +9,5 @@ class BsdGetVtmBandwidth(Action):
     def run(self, vtm, stringify):
 
         bsd = Bsd(self.config, self.logger)
-        result = bsd.getBandwidth(vtm, stringify)
-        return result
+        result = bsd.get_bandwidth(vtm, stringify)
+        return (True, result)

--- a/actions/bsd_license_vtm.py
+++ b/actions/bsd_license_vtm.py
@@ -9,5 +9,5 @@ class BsdLicenseVtm(Action):
     def run(self, vtm, password, address, bw, fp):
 
         bsd = Bsd(self.config, self.logger)
-        result = bsd.addVtm(vtm, password, address, bw, fp)
-        return result
+        result = bsd.add_vtm(vtm, password, address, bw, fp)
+        return (True, result)

--- a/actions/bsd_list_vtms.py
+++ b/actions/bsd_list_vtms.py
@@ -9,5 +9,5 @@ class BsdListVtms(Action):
     def run(self, full, deleted, stringify):
 
         bsd = Bsd(self.config, self.logger)
-        result = bsd.listVtms(full, deleted, stringify)
-        return result
+        result = bsd.list_vtms(full, deleted, stringify)
+        return (True, result)

--- a/actions/bsd_set_vtm_bandwidth.py
+++ b/actions/bsd_set_vtm_bandwidth.py
@@ -9,4 +9,4 @@ class BsdSetVtmBandwidth(Action):
     def run(self, vtm, bw):
 
         bsd = Bsd(self.config, self.logger)
-        bsd.setBandwidth(vtm, bw)
+        bsd.set_bandwidth(vtm, bw)

--- a/actions/bsd_unlicense_vtm.py
+++ b/actions/bsd_unlicense_vtm.py
@@ -9,5 +9,5 @@ class BsdUnlicenseVtm(Action):
     def run(self, vtm):
 
         bsd = Bsd(self.config, self.logger)
-        result = bsd.delVtm(vtm)
-        return result
+        result = bsd.del_vtm(vtm)
+        return (True, result)

--- a/actions/chains/deploy_chain.yaml
+++ b/actions/chains/deploy_chain.yaml
@@ -6,8 +6,10 @@
       ref: "vadc.vtm_add_pool"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_pool"
+        name: "{{service}}"
         nodes: "{{nodes}}"
+        algorithm: least_connections
+        monitors: [ Ping ]
       on-success: "addtip"
       on-failure: "bitch"
     -
@@ -15,7 +17,7 @@
       ref: "vadc.vtm_add_tip"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_tip"
+        name: "{{service}}"
         vtms: "{{vtms}}"
         addresses: "{{addresses}}"
       on-success: "addvserver"
@@ -25,16 +27,16 @@
       ref: "vadc.vtm_add_vserver"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_vs"
-        tip: "{{service}}_tip"
-        pool: "{{service}}_pool"
+        name: "{{service}}"
+        tip: "{{service}}"
+        pool: "{{service}}"
       on-failure: "deltip"
     -
       name: "deltip"
       ref: "vadc.vtm_del_tip"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_tip"
+        name: "{{service}}"
       on-failure: "delpool"
       on-success: "delpool"
     -
@@ -42,7 +44,7 @@
       ref: "vadc.vtm_del_pool"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_pool"
+        name: "{{service}}"
       on-failure: "bitch"
       on-success: "bitch"
     -

--- a/actions/chains/undeploy_chain.yaml
+++ b/actions/chains/undeploy_chain.yaml
@@ -6,7 +6,7 @@
       ref: "vadc.vtm_del_vserver"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_vs"
+        name: "{{service}}"
       on-success: "deltip"
       on-failure: "bitch"
     -
@@ -14,7 +14,7 @@
       ref: "vadc.vtm_del_tip"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_tip"
+        name: "{{service}}"
       on-success: "delpool"
       on-failure: "bitch"
     -
@@ -22,7 +22,7 @@
       ref: "vadc.vtm_del_pool"
       parameters:
         vtm: "{{vtm}}"
-        name: "{{service}}_pool"
+        name: "{{service}}"
       on-failure: "bitch"
     -
       name: "bitch"

--- a/actions/lib/vadc.py
+++ b/actions/lib/vadc.py
@@ -3,15 +3,19 @@
 import requests
 import sys
 import json
+import yaml
 import time
+from os import path
 
 
-class Vadc:
+class Vadc(object):
 
     DEBUG = False
 
     def __init__(self, host, user, passwd, logger):
         requests.packages.urllib3.disable_warnings()
+        if host.endswith('/') == False:
+            host += "/"
         self.host = host
         self.user = user
         self.passwd = passwd
@@ -23,15 +27,29 @@ class Vadc:
         if Vadc.DEBUG:
             self.logger.debug(message)
 
-    def _initHTTP(self):
+    def _get_api_version(self, apiRoot):
+        url = self.host + apiRoot
+        res = self._get_config(url)
+        if res.status_code != 200:
+            raise Exception("Failed to locate API: {}, {}".format(res.status_code, res.text))
+        versions = res.json()
+        versions = versions["children"]
+        major=max([int(ver["name"].split('.')[0]) for ver in versions])
+        minor=max([int(ver["name"].split('.')[1]) for ver in versions if 
+            ver["name"].startswith(str(major))])
+        version = "{}.{}".format(major, minor)
+        self._debug("API Version: {}".format(version))
+        return version
+
+    def _init_http(self):
         self.client = requests.Session()
         self.client.auth = (self.user, self.passwd)
 
-    def _getConfig(self, url):
+    def _get_config(self, url, params=None):
         self._debug("URL: " + url)
         try:
-            self._initHTTP()
-            response = self.client.get(url, verify=False)
+            self._init_http()
+            response = self.client.get(url, verify=False, params=params)
         except:
             self.logger.error("Error: Unable to connect to API")
             raise Exception("Error: Unable to connect to API")
@@ -39,17 +57,27 @@ class Vadc:
         self._debug("Body: " + response.text)
         return response
 
-    def _pushConfig(self, url, config, method="PUT", ct="application/json"):
+    def _push_config(self, url, config, method="PUT", ct="application/json", params=None, extra=None):
         self._debug("URL: " + url)
         try:
-            self._initHTTP()
-            config = json.dumps(config)
+            self._init_http()
+            if ct == "application/json":
+                if extra is not None:
+                    try:
+                        if extra.startswith("{"):
+                            extra = json.loads(extra, encoding="utf-8")
+                        else:
+                            extra = yaml.load( extra )
+                        self._merge_extra(config, extra)
+                    except Exception as e:
+                        self.logger.warn("Failed to merge extra properties: {}".format(e))
+                config = json.dumps(config)
             if method == "PUT":
                 response = self.client.put(url, verify=False, data=config,
-                    headers={"Content-Type": ct})
+                    headers={"Content-Type": ct}, params=params)
             else:
                 response = self.client.post(url, verify=False, data=config,
-                    headers={"Content-Type": ct})
+                    headers={"Content-Type": ct}, params=params)
         except requests.exceptions.ConnectionError:
             self.logger.error("Error: Unable to connect to API")
             raise Exception("Error: Unable to connect to API")
@@ -59,10 +87,10 @@ class Vadc:
         self._debug("Body: " + response.text)
         return response
 
-    def _delConfig(self, url):
+    def _del_config(self, url):
         self._debug("URL: " + url)
         try:
-            self._initHTTP()
+            self._init_http()
             response = self.client.delete(url, verify=False)
         except requests.exceptions.ConnectionError:
             sys.stderr.write("Error: Unable to connect to API {}".format(url))
@@ -72,18 +100,35 @@ class Vadc:
         self._debug("Body: " + response.text)
         return response
 
+    def _upload_raw_binary(self, url, filename):
+        if path.isfile(filename) is False:
+            raise Exception("File: {} does not exist".format(filename))
+        if path.getsize(filename) > 20480000:
+            raise Exception("File: {} is too large.".format(filename))
+        handle = open(filename, "rb")
+        body = handle.read()
+        handle.close()
+        return self._push_config(url, body, ct="application/octet-stream")
+
     def _dictify(self, listing, keyName):
         dictionary = {}
         for item in listing:
             k = item.pop(keyName)
             dictionary[k] = item
 
-    def _cacheStore(self, key, data, timeout=10):
+    def _merge_extra(self, obj1, obj2):
+        for section in obj2["properties"].keys():
+            if section in obj1["properties"].keys():
+                obj1["properties"][section].update(obj2["properties"][section])
+            else:
+                obj1["properties"][section] = obj2["properties"][section]
+
+    def _cache_store(self, key, data, timeout=10):
         exp = time.time() + timeout
         self._debug("Cache Store: {}".format(key))
         self._cache[key] = {"exp": exp, "data": data}
 
-    def _cacheLookup(self, key):
+    def _cache_lookup(self, key):
         now = time.time()
         if key in self._cache:
             entry = self._cache[key]
@@ -93,10 +138,10 @@ class Vadc:
         self._debug("Cache Miss: {}".format(key))
         return None
 
-    def dumpCache(self):
+    def dump_cache(self):
         return json.dumps(self._cache, encoding="utf-8")
 
-    def loadCache(self, cache):
+    def load_cache(self, cache):
         self._cache = json.loads(cache, encoding="utf-8")
 
 
@@ -111,12 +156,49 @@ class Bsd(Vadc):
         except KeyError:
             raise ValueError("brcd_sd_host, brcd_sd_user, and brcd_sd_pass must be configured")
 
-        Vadc.__init__(self, host, user, passwd, logger)
-        if host.endswith('/') == False:
-            host += "/"
-        self.baseUrl = host + "api/tmcm/2.2"
+        super(Bsd, self).__init__(host, user, passwd, logger)
+        self.version = self._get_api_version("api/tmcm")
+        self.baseUrl = host + "api/tmcm/" + self.version
 
-    def addVtm(self, vtm, password, address, bw, fp):
+    def _get_vtm_licenses(self):
+        url = self.baseUrl + "/license"
+        res = self._get_config(url)
+        if res.status_code != 200:
+            raise Exception("Failed to get licenses: {}, {}".format(res.status_code, res.text))
+        licenses = res.json()
+        licenses = licenses["children"]
+        universal = [int(lic["name"][11:]) for lic in licenses
+            if lic["name"].startswith("universal_v")]
+        universal.sort(reverse=True)
+        legacy = [float(lic["name"][7:]) for lic in licenses
+            if lic["name"].startswith("legacy_")]
+        legacy.sort(reverse=True)
+        order = []
+        order += (["universal_v" + str(ver) for ver in universal])
+        order += (["legacy_" + str(ver) for ver in legacy])
+        return order
+
+    def get_cluster_members(self, cluster):
+        url = self.baseUrl + "/cluster/" + cluster
+        res = self._get_config(url)
+        if res.status_code != 200:
+            raise Exception("Failed to locate cluster: {}, {}".format(res.status_code, res.text))
+        config = res.json()
+        return config["members"]
+
+    def get_active_vtm(self, vtms=None, cluster=None):
+        if cluster is None and vtms is None:
+            raise Exception("Error - You must supply either a list of vTMs or a Cluster ID")
+        if cluster is not None and cluster != "":
+            vtms = self.get_cluster_members(cluster)
+        for vtm in vtms:
+            url = self.baseUrl + "/instance/" + vtm + "/tm/"
+            res = self._get_config(url)
+            if res.status_code == 200:
+                return vtm
+        return None
+
+    def add_vtm(self, vtm, password, address, bw, fp):
         url = self.baseUrl + "/instance/?managed=false"
 
         if address is None:
@@ -129,47 +211,55 @@ class Bsd(Vadc):
         if password is not None:
             config["admin_password"] = password
             config["rest_enabled"] = True
-            config["license_name"] = "universal_v3"
 
-        res = self._pushConfig(url, config, "POST")
+            # Try each of our available licenses.
+            licenses = self._get_vtm_licenses()
+            for license in licenses:
+                config["license_name"] = license
+                res = self._push_config(url, config, "POST")
+                if res.status_code == 201:
+                    break
+        else:
+            res = self._push_config(url, config, "POST")
+
         if res.status_code != 201:
             raise Exception("Failed to add vTM. Response: {}, {}".format(res.status_code, res.text))
         return res.json()
 
-    def delVtm(self, vtm):
+    def del_vtm(self, vtm):
         url = self.baseUrl + "/instance/" + vtm
         config = {"status": "deleted"}
-        res = self._pushConfig(url, config, "POST")
+        res = self._push_config(url, config, "POST")
         if res.status_code != 200:
             raise Exception("Failed to del vTM. Response: {}, {}".format(res.status_code, res.text))
         return res.json()
 
-    def getVtm(self, tag):
-        vtm = self._cacheLookup("getVtm_" + tag)
+    def get_vtm(self, tag):
+        vtm = self._cache_lookup("get_vtm_" + tag)
         if vtm is None:
             url = self.baseUrl + "/instance/" + tag
-            res = self._getConfig(url)
+            res = self._get_config(url)
             if res.status_code != 200:
                 raise Exception("Failed to get vTM {}. Response: {}, {}".format(
                     vtm, res.status_code, res.text))
             vtm = res.json()
-            self._cacheStore("getVtm_" + tag, vtm)
+            self._cache_store("get_vtm_" + tag, vtm)
         return vtm
 
-    def listVtms(self, full, deleted, stringify):
-        instances = self._cacheLookup("listVtms")
+    def list_vtms(self, full, deleted, stringify):
+        instances = self._cache_lookup("list_vtms")
         if instances is None:
             url = self.baseUrl + "/instance/"
-            res = self._getConfig(url)
+            res = self._get_config(url)
             if res.status_code != 200:
                 raise Exception("Failed to list vTMs. Response: {}, {}".format(
                     res.status_code, res.text))
             instances = res.json()
-            self._cacheStore("listVtms", instances)
+            self._cache_store("list_vtms", instances)
 
         output = []
         for instance in instances["children"]:
-            config = self.getVtm(instance["name"])
+            config = self.get_vtm(instance["name"])
             if deleted is False and config["status"] == "Deleted":
                 continue
             if full:
@@ -186,17 +276,33 @@ class Bsd(Vadc):
         else:
             return output
 
-    def getStatus(self, vtm=None, stringify=False):
-        instances = self._cacheLookup("getStatus")
+    def _submit_backup_task(self, vtm=None, cluster_id=None, tag=None):
+        if self.version < 2.3:
+            raise Exception("You need to be running BSD version 2.5 or newer to perform a backup")
+        url = self.baseUrl + "/config/backup/task"
+        if cluster_id is None:
+            if vtm is None:
+                raise Exception("You need to provide with a vTM or Cluster-ID")
+            cluster_id = self._get_cluster_for_vtm(cluster)
+        config = { "cluster_id": cluster_id, "task_type": "backup restore",
+            "task_subtype": "backup now" }
+        res = self._push_config(url, config, "POST")
+        if res.status_code != 201:
+            raise Exception("Failed to create BackUp, Response: {}, {}".format(
+                res.status_code, res.text))
+        return res.json()
+
+    def get_status(self, vtm=None, stringify=False):
+        instances = self._cache_lookup("get_status")
         if instances is None:
             url = self.baseUrl + "/monitoring/instance"
-            res = self._getConfig(url)
+            res = self._get_config(url)
             if res.status_code != 200:
                 raise Exception("Failed get Status. Result: {}, {}".format(
                     res.status_code, res.text))
 
             instances = res.json()
-            self._cacheStore("getStatus", instances)
+            self._cache_store("get_status", instances)
 
         if vtm is not None:
             for instance in instances:
@@ -208,8 +314,8 @@ class Bsd(Vadc):
         else:
             return instances
 
-    def getErrors(self, stringify=False):
-        instances = self.getStatus()
+    def get_errors(self, stringify=False):
+        instances = self.get_status()
         errors = {}
         for instance in instances:
             error = {}
@@ -235,17 +341,17 @@ class Bsd(Vadc):
         else:
             return errors
 
-    def getMonitorIntervals(self, setting=None):
-        intervals = self._cacheLookup("getMonitorIntervals")
+    def get_monitor_intervals(self, setting=None):
+        intervals = self._cache_lookup("get_monitor_intervals")
         if intervals is None:
             url = self.baseUrl + "/settings/monitoring"
-            res = self._getConfig(url)
+            res = self._get_config(url)
             if res.status_code != 200:
                 raise Exception("Failed to get Monitoring Intervals. Result: {}, {}".format(
                     res.status_code, res.text))
 
             intervals = res.json()
-            self._cacheStore("getMonitorIntervals", intervals)
+            self._cache_store("get_monitor_intervals", intervals)
 
         if setting is not None:
             if setting not in intervals:
@@ -253,11 +359,11 @@ class Bsd(Vadc):
             return intervals[setting]
         return intervals
 
-    def getBandwidth(self, vtm=None, stringify=False):
-        instances = self.getStatus(vtm)
+    def get_bandwidth(self, vtm=None, stringify=False):
+        instances = self.get_status(vtm)
         bandwidth = {}
         for instance in instances:
-            config = self.getVtm(instance["name"])
+            config = self.get_vtm(instance["name"])
             tag = config["tag"]
             # Bytes/Second
             if "throughput_out" in instance:
@@ -279,10 +385,10 @@ class Bsd(Vadc):
         else:
             return bandwidth
 
-    def setBandwidth(self, vtm, bw):
+    def set_bandwidth(self, vtm, bw):
         url = self.baseUrl + "/instance/" + vtm
         config = {"bandwidth": bw}
-        res = self._pushConfig(url, config)
+        res = self._push_config(url, config)
         if res.status_code != 200:
             raise Exception("Failed to set Bandwidth. Result: {}, {}".format(
                 res.status_code, res.text))
@@ -308,54 +414,60 @@ class Vtm(Vadc):
             raise ValueError("You must set key brcd_sd_proxy, and either " +
                 "brcd_sd_[host|user|pass] or brcd_vtm_[host|user|pass].")
 
-        Vadc.__init__(self, host, user, passwd, logger)
-        if host.endswith('/') == False:
-            host += "/"
+        self.vtm = vtm
+        self.bsdVersion = None
+        super(Vtm, self).__init__(host, user, passwd, logger)
         if self._proxy:
-            self.baseUrl = host + "api/tmcm/2.2/instance/{}/tm/3.8/config/active".format(vtm)
+            self.bsdVersion = self._get_api_version("api/tmcm")
+            self.version = self._get_api_version(
+                "api/tmcm/{}/instance/{}/tm".format(self.bsdVersion, vtm))
+            self.baseUrl = host + "api/tmcm/{}".format(self.bsdVersion) + \
+                "/instance/{}/tm/{}".format(vtm, self.version)
         else:
-            self.baseUrl = host + "api/tm/3.8/config/active"
+            self.version = self._get_api_version("api/tm")
+            self.baseUrl = host + "api/tm/{}".format(self.version)
+        self.configUrl = self.baseUrl + "/config/active"
+        self.statusUrl = self.baseUrl + "/status/local_tm"
 
-    def _getNodeTable(self, name):
-        url = self.baseUrl + "/pools/" + name
-        res = self._getConfig(url)
+    def _get_node_table(self, name):
+        url = self.configUrl + "/pools/" + name
+        res = self._get_config(url)
         if res.status_code != 200:
             raise Exception("Failed to get pool. Result: {}, {}".format(res.status_code, res.text))
 
         config = res.json()
         return config["properties"]["basic"]["nodes_table"]
 
-    def _getVSConfig(self, name):
-        url = self.baseUrl + "/virtual_servers/" + name
-        res = self._getConfig(url)
+    def _get_vs_config(self, name):
+        url = self.configUrl + "/virtual_servers/" + name
+        res = self._get_config(url)
         if res.status_code != 200:
             raise Exception("Failed to get VS. Result: {}, {}".format(res.status_code, res.text))
 
         config = res.json()
         return config
 
-    def _setVSConfig(self, name, config):
-        url = self.baseUrl + "/virtual_servers/" + name
-        res = self._pushConfig(url, config)
+    def _set_vs_config(self, name, config):
+        url = self.configUrl + "/virtual_servers/" + name
+        res = self._push_config(url, config)
         if res.status_code != 200:
             raise Exception("Failed to set VS. Result: {}, {}".format(res.status_code, res.text))
-        config = res.json()
-        return config
+        return res
 
-    def _getVSRules(self, name):
-        config = self._getVSConfig(name)
+    def _get_vs_rules(self, name):
+        config = self._get_vs_config(name)
         rules = {k: config["properties"]["basic"][k] for k in
                 ("request_rules", "response_rules", "completionrules")}
         return rules
 
-    def _setVSRules(self, name, rules):
+    def _set_vs_rules(self, name, rules):
         config = {"properties": {"basic": rules}}
-        res = self._setVSConfig(name, config)
+        res = self._set_vs_config(name, config)
         if res.status_code != 200:
             raise Exception("Failed set VS Rules. Result: {}, {}".format(res.status_code, res.text))
 
-    def insertRule(self, vsname, rulename, insert=True):
-        rules = self._getVSRules(vsname)
+    def insert_rule(self, vsname, rulename, insert=True):
+        rules = self._get_vs_rules(vsname)
         if insert:
             if rulename in rules["request_rules"]:
                 raise Exception("VServer {} already in maintenance".format(vsname))
@@ -364,13 +476,13 @@ class Vtm(Vadc):
             if rulename not in rules["request_rules"]:
                 raise Exception("VServer {} is not in maintenance".format(vsname))
             rules["request_rules"].remove(rulename)
-        self._setVSRules(vsname, rules)
+        self._set_vs_rules(vsname, rules)
 
-    def enableMaintenance(self, vsname, rulename="maintenance", enable=True):
-        self.insertRule(vsname, rulename, enable)
+    def enable_maintenance(self, vsname, rulename="maintenance", enable=True):
+        self.insert_rule(vsname, rulename, enable)
 
-    def getPoolNodes(self, name):
-        nodeTable = self._getNodeTable(name)
+    def get_pool_nodes(self, name):
+        nodeTable = self._get_node_table(name)
         nodes = {"active": [], "disabled": [], "draining": []}
         for node in nodeTable:
             if node["state"] == "active":
@@ -384,9 +496,23 @@ class Vtm(Vadc):
 
         return nodes
 
-    def drainNodes(self, name, nodes, drain=True):
-        url = self.baseUrl + "/pools/" + name
-        nodeTable = self._getNodeTable(name)
+    def set_pool_nodes(self, name, active, draining, disabled):
+        url = self.configUrl + "/pools/" + name
+        nodeTable = []
+        if active is not None and active:
+            nodeTable.extend( [{"node": node, "state": "active"} for node in active] )
+        if draining is not None and draining:
+            nodeTable.extend( [{"node": node, "state": "draining"} for node in draining] )
+        if disabled is not None and disabled:
+            nodeTable.extend( [{"node": node, "state": "disabled"} for node in disabled] )
+        config = {"properties": {"basic": {"nodes_table": nodeTable }}}
+        res = self._push_config(url, config)
+        if res.status_code != 201 and res.status_code != 200:
+            raise Exception("Failed to set pool nodes. Result: {}, {}".format(res.status_code, res.text))
+
+    def drain_nodes(self, name, nodes, drain=True):
+        url = self.configUrl + "/pools/" + name
+        nodeTable = self._get_node_table(name)
         for entry in nodeTable:
             if entry["node"] in nodes:
                 if drain:
@@ -395,101 +521,109 @@ class Vtm(Vadc):
                     entry["state"] = "active"
 
         config = {"properties": {"basic": {"nodes_table": nodeTable}}}
-        res = self._pushConfig(url, config)
+        res = self._push_config(url, config)
         if res.status_code != 201 and res.status_code != 200:
             raise Exception("Failed to add pool. Result: {}, {}".format(res.status_code, res.text))
 
-    def addPool(self, name, nodes, algorithm, persistence, monitors):
-        url = self.baseUrl + "/pools/" + name
+    def add_pool(self, name, nodes, algorithm, persistence, monitors, extra=None):
+        url = self.configUrl + "/pools/" + name
 
         nodeTable = []
         for node in nodes:
             nodeTable.append({"node": node, "state": "active"})
 
-        config = {"properties": {"basic": {"nodes_table": nodeTable, "monitors": monitors,
-            "persistence_class": persistence}, "load_balancing": {"algorithm": algorithm}}}
+        config = {"properties": {"basic": {"nodes_table": nodeTable}, "load_balancing": {}}}
 
-        res = self._pushConfig(url, config)
+        if monitors is not None:
+            config["properties"]["basic"]["monitors"] = monitors
+
+        if persistence is not None:
+            config["properties"]["basic"]["persistence_class"] = persistence
+
+        if algorithm is not None:
+            config["properties"]["load_balancing"]["algorithm"] = algorithm
+
+        res = self._push_config(url, config, extra=extra)
         if res.status_code != 201 and res.status_code != 200:
             raise Exception("Failed to add pool. Result: {}, {}".format(res.status_code, res.text))
 
-    def delPool(self, name):
-        url = self.baseUrl + "/pools/" + name
-        res = self._delConfig(url)
+    def del_pool(self, name):
+        url = self.configUrl + "/pools/" + name
+        res = self._del_config(url)
         if res.status_code != 204:
             raise Exception("Failed to del pool. Result: {}, {}".format(res.status_code, res.text))
 
-    def addVserver(self, name, pool, tip, port, protocol):
-        url = self.baseUrl + "/virtual_servers/" + name
+    def add_vserver(self, name, pool, tip, port, protocol, extra=None):
+        url = self.configUrl + "/virtual_servers/" + name
         config = {"properties": {"basic": {"pool": pool, "port": port, "protocol": protocol,
             "listen_on_any": False, "listen_on_traffic_ips": [tip], "enabled": True}}}
 
-        res = self._pushConfig(url, config)
-        if res.status_code != 201:
+        res = self._push_config(url, config, extra=extra)
+        if res.status_code != 201 and res.status_code != 200:
             raise Exception("Failed to add VS. Result: {}, {}".format(res.status_code, res.text))
 
-    def delVserver(self, name):
-        url = self.baseUrl + "/virtual_servers/" + name
-        res = self._delConfig(url)
+    def del_vserver(self, name):
+        url = self.configUrl + "/virtual_servers/" + name
+        res = self._del_config(url)
         if res.status_code != 204:
             raise Exception("Failed to del VS. Result: {}, {}".format(res.status_code, res.text))
 
-    def addTip(self, name, vtms, addresses):
-        url = self.baseUrl + "/traffic_ip_groups/" + name
+    def add_tip(self, name, vtms, addresses, extra=None):
+        url = self.configUrl + "/traffic_ip_groups/" + name
 
         config = {"properties": {"basic": {"ipaddresses": addresses,
             "machines": vtms, "enabled": True}}}
 
-        res = self._pushConfig(url, config)
-        if res.status_code != 201:
+        res = self._push_config(url, config, extra=extra)
+        if res.status_code != 201 and res.status_code != 200:
             raise Exception("Failed to add TIP. Result: {}, {}".format(res.status_code, res.text))
 
-    def delTip(self, name):
-        url = self.baseUrl + "/traffic_ip_groups/" + name
-        res = self._delConfig(url)
+    def del_tip(self, name):
+        url = self.configUrl + "/traffic_ip_groups/" + name
+        res = self._del_config(url)
         if res.status_code != 204:
             raise Exception("Failed to del TIP. Result: {}, {}".format(res.status_code, res.text))
 
-    def addServerCert(self, name, public, private):
-        url = self.baseUrl + "/ssl/server_keys/" + name
+    def add_server_cert(self, name, public, private):
+        url = self.configUrl + "/ssl/server_keys/" + name
 
         public = public.replace("\\n", "\n")
         private = private.replace("\\n", "\n")
 
         config = {"properties": {"basic": {"public": public, "private": private}}}
 
-        res = self._pushConfig(url, config)
+        res = self._push_config(url, config)
         if res.status_code != 201 and res.status_code != 200:
             raise Exception("Failed to add Server Certificate." +
                 " Result: {}, {}".format(res.status_code, res.text))
 
-    def delServerCert(self, name):
-        url = self.baseUrl + "/ssl/server_keys/" + name
-        res = self._delConfig(url)
+    def del_server_cert(self, name):
+        url = self.configUrl + "/ssl/server_keys/" + name
+        res = self._del_config(url)
         if res.status_code != 204:
             raise Exception("Failed to delete Server Certificate." +
                 " Result: {}, {}".format(res.status_code, res.text))
 
-    def enableSSLOffload(self, name, cert="", on=True, xproto=False, headers=False):
-        url = self.baseUrl + "/virtual_servers/" + name
+    def enable_ssl_offload(self, name, cert="", on=True, xproto=False, headers=False):
+        url = self.configUrl + "/virtual_servers/" + name
         config = {"properties": {"basic": {"ssl_decrypt": on, "add_x_forwarded_proto": xproto},
             "ssl": {"add_http_headers": headers, "server_cert_default": cert}}}
 
-        res = self._pushConfig(url, config)
+        res = self._push_config(url, config)
         if res.status_code != 200:
             raise Exception("Failed to configure SSl Offload on {}.".format(name) +
                 " Result: {}, {}".format(res.status_code, res.text))
 
-    def enableSSLEncryption(self, name, on=True, verify=False):
-        url = self.baseUrl + "/pools/" + name
+    def enable_ssl_encryption(self, name, on=True, verify=False):
+        url = self.configUrl + "/pools/" + name
         config = {"properties": {"ssl": {"enable": on, "strict_verify": verify}}}
 
-        res = self._pushConfig(url, config)
+        res = self._push_config(url, config)
         if res.status_code != 200:
             raise Exception("Failed to configure SSl Encryption on {}.".format(name) +
                 " Result: {}, {}".format(res.status_code, res.text))
 
-    def addSessionPersistence(self, name, method, cookie=None):
+    def add_session_persistence(self, name, method, cookie=None):
         types = ["ip", "universal", "named", "transparent", "cookie", "j2ee", "asp", "ssl"]
         if method not in types:
             raise Exception("Failed to add SP Class. Invalid method: {}".format(method) +
@@ -500,17 +634,109 @@ class Vtm(Vadc):
         if cookie is None:
             cookie = ""
 
-        url = self.baseUrl + "/persistence/" + name
+        url = self.configUrl + "/persistence/" + name
         config = {"properties": {"basic": {"type": method, "cookie": cookie}}}
 
-        res = self._pushConfig(url, config)
+        res = self._push_config(url, config)
         if res.status_code != 201 and res.status_code != 200:
             raise Exception("Failed to add Session Persistence Class" +
                 " Result: {}, {}".format(res.status_code, res.text))
 
-    def delSessionPersistence(self, name):
-        url = self.baseUrl + "/persistence/" + name
-        res = self._delConfig(url)
+    def del_session_persistence(self, name):
+        url = self.configUrl + "/persistence/" + name
+        res = self._del_config(url)
         if res.status_code != 204:
             raise Exception("Failed to delete Session Persistence Class." +
                 " Result: {}, {}".format(res.status_code, res.text))
+
+    def list_backups(self):
+        if self.version < 3.9:
+            raise Exception("Backups require vTM 11.0 or newer")
+        url = self.statusUrl + "/backups/full" 
+        res = self._get_config(url)
+        if res.status_code != 200:
+            raise Exception("Failed to get Backup Listing." +
+                " Result: {}, {}".format(res.status_code, res.text))
+        listing = res.json()["children"]
+        output = {}
+        for backup in [backup["name"] for backup in listing]:
+            url = self.statusUrl + "/backups/full/" + backup
+            res = self._get_config(url)
+            if res.status_code == 200:
+                out = res.json()
+                output[backup] = out["properties"]["backup"]
+        return output
+
+    def create_backup(self, name, description):
+        if self.version < 3.9:
+            raise Exception("Backups require vTM 11.0 or newer")
+        url = self.statusUrl + "/backups/full/" + name
+        description="" if description is None else description
+        config = {"properties": {"backup": {"description": description }}}
+        res = self._push_config(url, config)
+        if res.status_code != 201 and res.status_code != 200:
+            raise Exception("Failed to create Backup." +
+                " Result: {}, {}".format(res.status_code, res.text))
+
+    def restore_backup(self, name):
+        if self._proxy and self.bsdVersion < 2.4:
+            raise Exception("Backup restoration requires BSD Version 2.6 when proxying.")
+        if self.version < 3.9:
+            raise Exception("Backups require vTM 11.0 or newer")
+        url = self.statusUrl + "/backups/full/" + name +"?restore"
+        config = {"properties": {}}
+        res = self._push_config(url, config)
+        if res.status_code != 200:
+            raise Exception("Failed to create Backup." +
+                " Result: {}, {}".format(res.status_code, res.text))
+        return res.json()
+
+    def delete_backup(self, name):
+        if self.version < 3.9:
+            raise Exception("Backups require vTM 11.0 or newer")
+        url = self.statusUrl + "/backups/full/" + name
+        res = self._del_config(url)
+        if res.status_code != 204:
+            raise Exception("Failed to delete Backup." +
+                " Result: {}, {}".format(res.status_code, res.text))
+
+    def upload_action_program(self, name, filename):
+        url = self.configUrl + "/action_programs/" + name
+        res = self._upload_raw_binary(url, filename)
+        if res.status_code != 201 and res.status_code != 204:
+            raise Exception("Failed to upload program." +
+                " Result: {}, {}".format(res.status_code, res.text))
+
+    def add_action_program(self, name, program, arguments):
+        config = {"properties": {"basic": {"type": "program"}, "program": {"arguments": arguments, "program": program}}}
+        url = self.configUrl + "/actions/" + name
+        res = self._push_config(url, config)
+        if res.status_code != 200 and res.status_code != 201:
+            raise Exception("Failed to add action." +
+                " Result: {}, {}".format(res.status_code, res.text))
+
+    def get_event_type(self, name):
+        url = self.configUrl + "/event_types/" + name
+        res = self._get_config(url)
+        if res.status_code == 404:
+            return None
+        elif res.status_code != 200:
+            raise Exception("Failed to get event." +
+                " Result: {}, {}".format(res.status_code, res.text))
+        return res.json()
+
+    def add_event_type_action(self, event, action):
+        url = self.configUrl + "/event_types/" + event
+        config = self.get_event_type(event)
+        if config is None:
+            return False
+        entries = config["properties"]["basic"]["actions"]
+        if action in entries:
+            return True
+        entries.append(action)
+        res = self._push_config(url, config)
+        if res.status_code != 200:
+            raise Exception("Failed to Set Action: {}".format(action) +
+                " for Event: {}.".format(event) +
+                " Result: {}, {}".format(res.status_code, res.text))
+

--- a/actions/lib/vadc.py
+++ b/actions/lib/vadc.py
@@ -6,7 +6,6 @@ import json
 import yaml
 import time
 from os import path
-from base64 import b64encode, b64decode
 
 
 class Vadc(object):
@@ -701,7 +700,7 @@ class Vtm(Vadc):
             raise Exception("Failed to delete Backup." +
                 " Result: {}, {}".format(res.status_code, res.text))
 
-    def get_backup(self, name, b64=True):
+    def get_backup(self, name):
         if self.version < 3.9:
             raise Exception("Backups require vTM 11.0 or newer")
         url = self.statusUrl + "/backups/full/" + name
@@ -710,8 +709,17 @@ class Vtm(Vadc):
         if res.status_code != 200:
             raise Exception("Failed to download Backup." +
                 " Result: {}, {}".format(res.status_code, res.text))
-        backup = b64encode(res.content) if b64 else res.content
+        backup = res.content
         return backup
+
+    def upload_backup(self, backup):
+        if self.version < 3.9:
+            raise Exception("Backups require vTM 11.0 or newer")
+        url = self.statusUrl + "/backups/full/"
+        res = self._push_config(url, backup, method="POST", ct="application/x-tar")
+        if res.status_code != 201 and res.status_code != 204:
+            raise Exception("Failed to upload Backup." +
+                " Result: {}, {}".format(res.status_code, res.text))
 
     def upload_action_program(self, name, filename):
         url = self.configUrl + "/action_programs/" + name

--- a/actions/lib/vadc.py
+++ b/actions/lib/vadc.py
@@ -6,6 +6,7 @@ import json
 import yaml
 import time
 from os import path
+from base64 import b64encode, b64decode
 
 
 class Vadc(object):
@@ -45,11 +46,11 @@ class Vadc(object):
         self.client = requests.Session()
         self.client.auth = (self.user, self.passwd)
 
-    def _get_config(self, url, params=None):
+    def _get_config(self, url, headers=None, params=None):
         self._debug("URL: " + url)
         try:
             self._init_http()
-            response = self.client.get(url, verify=False, params=params)
+            response = self.client.get(url, verify=False, headers=headers, params=params)
         except:
             self.logger.error("Error: Unable to connect to API")
             raise Exception("Error: Unable to connect to API")
@@ -699,6 +700,18 @@ class Vtm(Vadc):
         if res.status_code != 204:
             raise Exception("Failed to delete Backup." +
                 " Result: {}, {}".format(res.status_code, res.text))
+
+    def get_backup(self, name, b64=True):
+        if self.version < 3.9:
+            raise Exception("Backups require vTM 11.0 or newer")
+        url = self.statusUrl + "/backups/full/" + name
+        headers = {"Accept": "application/x-tar"}
+        res = self._get_config(url, headers=headers)
+        if res.status_code != 200:
+            raise Exception("Failed to download Backup." +
+                " Result: {}, {}".format(res.status_code, res.text))
+        backup = b64encode(res.content) if b64 else res.content
+        return backup
 
     def upload_action_program(self, name, filename):
         url = self.configUrl + "/action_programs/" + name

--- a/actions/remediate_pool_failure.py
+++ b/actions/remediate_pool_failure.py
@@ -17,19 +17,19 @@ class RemediatePoolFailure(Action):
         instance = errors["name"]
         vtm = Vtm(self.config, self.logger, instance)
         bsd = Bsd(self.config, self.logger)
-        status = bsd.getStatus(instance)[0]
+        status = bsd.get_status(instance)[0]
 
         nodes = errors["traffic_health"]["failed_nodes"]
         failedPools = {pool: [node["node"] for node in nodes for pool in node["pools"]]
             for node in nodes for pool in node["pools"]}
 
         for pool in failedPools.keys():
-            nodes = vtm.getPoolNodes(pool)
+            nodes = vtm.get_pool_nodes(pool)
             if set(nodes["active"]).issubset(failedPools[pool]):
                 self.logger.debug("Pool Dead")
                 for vs in status["traffic_health"]["virtual_servers"]:
                     if vs["pool"] == pool:
                         self.logger.debug("Putting VS: {} into maintenance.".format(vs["name"]))
-                        vtm.enableMaintenance(vs["name"], "maintenance")
+                        vtm.enable_maintenance(vs["name"], "maintenance")
             else:
                 self.logger.debug("Pool not dead")

--- a/actions/vtm_add_backup.py
+++ b/actions/vtm_add_backup.py
@@ -17,7 +17,7 @@ class VtmAddBackup(Action):
             backup = fh.read()
             fh.close()
         else:
-            sys.stderr.write("File does not exist: {}\n".format(outfile))
+            sys.stderr.write("File does not exist: {}\n".format(tarball))
             return (False, None)
 
         result = vtm.upload_backup(backup)

--- a/actions/vtm_add_backup.py
+++ b/actions/vtm_add_backup.py
@@ -11,7 +11,7 @@ class VtmAddBackup(Action):
     def run(self, vtm, tarball):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        
+
         if path.exists(tarball) is True:
             fh = open(tarball, "rb")
             backup = fh.read()

--- a/actions/vtm_add_backup.py
+++ b/actions/vtm_add_backup.py
@@ -1,0 +1,24 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+from os import path
+import sys
+
+
+class VtmAddBackup(Action):
+
+    def run(self, vtm, tarball):
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        
+        if path.exists(tarball) is True:
+            fh = open(tarball, "rb")
+            backup = fh.read()
+            fh.close()
+        else:
+            sys.stderr.write("File does not exist: {}\n".format(outfile))
+            return (False, None)
+
+        result = vtm.upload_backup(backup)
+        return (True, result)

--- a/actions/vtm_add_backup.yaml
+++ b/actions/vtm_add_backup.yaml
@@ -1,0 +1,14 @@
+description: 'vTM - Upload a Configuration Backup'
+enabled: true
+entry_point: vtm_add_backup.py
+name: vtm_add_backup
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure, the tag or instance ID on BSD."
+    type: string
+    required: true
+  tarball:
+    description: "tarball file name"
+    type: string
+    required: true

--- a/actions/vtm_add_persistence.py
+++ b/actions/vtm_add_persistence.py
@@ -9,4 +9,4 @@ class VtmAddPersistence(Action):
     def run(self, vtm, name, method, cookie):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.addSessionPersistence(name, method, cookie)
+        vtm.add_session_persistence(name, method, cookie)

--- a/actions/vtm_add_pool.py
+++ b/actions/vtm_add_pool.py
@@ -6,7 +6,7 @@ from lib.vadc import Vtm
 
 class VtmAddPool(Action):
 
-    def run(self, vtm, name, nodes, algorithm, persistence, monitors):
+    def run(self, vtm, name, nodes, algorithm, persistence, monitors, extra):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.addPool(name, nodes, algorithm, persistence, monitors)
+        vtm.add_pool(name, nodes, algorithm, persistence, monitors, extra)

--- a/actions/vtm_add_pool.yaml
+++ b/actions/vtm_add_pool.yaml
@@ -18,16 +18,17 @@ parameters:
     type: array
   algorithm:
     description: "Load Balancing algorithm for the pool"
-    default: 'least_connections'
     type: string
     required: false
   persistence:
     description: "Persistence class for the pool"
-    default: ""
     type: string
     required: false
   monitors:
     description: "Health Monitor for the pool"
-    default: ["Ping"]
     type: array
+    required: false
+  extra:
+    description: "Additional JSON/YAML properties to merge during creation"
+    type: string
     required: false

--- a/actions/vtm_add_server_cert.py
+++ b/actions/vtm_add_server_cert.py
@@ -9,4 +9,4 @@ class VtmAddServerCert(Action):
     def run(self, vtm, name, public, private):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.addServerCert(name, public, private)
+        vtm.add_server_cert(name, public, private)

--- a/actions/vtm_add_tip.py
+++ b/actions/vtm_add_tip.py
@@ -6,7 +6,7 @@ from lib.vadc import Vtm
 
 class VtmAddTip(Action):
 
-    def run(self, vtm, name, vtms, addresses):
+    def run(self, vtm, name, vtms, addresses, extra):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.addTip(name, vtms, addresses)
+        vtm.add_tip(name, vtms, addresses, extra)

--- a/actions/vtm_add_tip.yaml
+++ b/actions/vtm_add_tip.yaml
@@ -20,3 +20,7 @@ parameters:
     description: "The IP Addresses in the TIP Group"
     required: true
     type: array
+  extra:
+    description: "Additional JSON/YAML properties to merge during creation"
+    type: string
+    required: false

--- a/actions/vtm_add_vserver.py
+++ b/actions/vtm_add_vserver.py
@@ -6,7 +6,7 @@ from lib.vadc import Vtm
 
 class VtmAddVserver(Action):
 
-    def run(self, vtm, name, pool, tip, port, protocol):
+    def run(self, vtm, name, pool, tip, port, protocol, extra):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.addVserver(name, pool, tip, port, protocol)
+        vtm.add_vserver(name, pool, tip, port, protocol, extra)

--- a/actions/vtm_add_vserver.yaml
+++ b/actions/vtm_add_vserver.yaml
@@ -30,3 +30,7 @@ parameters:
     required: false
     type: string
     default: "http"
+  extra:
+    description: "Additional JSON/YAML properties to merge during creation"
+    type: string
+    required: false

--- a/actions/vtm_add_webhook_action.py
+++ b/actions/vtm_add_webhook_action.py
@@ -1,0 +1,21 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+
+
+class VtmAddWebhookAction(Action):
+
+    def run(self, vtm, name, api_hook, api_key, event):
+
+        arguments = [{"name": "api-hook", "description": "St2 API Webhook", "value": api_hook},
+            {"name": "api-key", "description": "St2 API Token", "value": api_key}]
+
+        program = "/opt/stackstorm/packs/vadc/files/st2-trigger.py"
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        vtm.upload_action_program("st2-trigger.py", program)
+        vtm.add_action_program(name, "st2-trigger.py", arguments)
+        if event is not None:
+            vtm.add_event_type_action(event, name)
+        return (True, None)

--- a/actions/vtm_add_webhook_action.yaml
+++ b/actions/vtm_add_webhook_action.yaml
@@ -1,0 +1,28 @@
+description: 'vTM - Create StackStorm Alerting Action for webhook callback'
+enabled: true
+entry_point: vtm_add_webhook_action.py
+name: vtm_add_webhook_action
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure, the tag or instance ID on BSD."
+    type: string
+    required: true
+  api_key:
+    description: "The St2 API-Key for use with this trigger"
+    type: string
+    secret: true
+    required: true
+  api_hook:
+    description: "The St2 API-Hook URL. Eg: https://stackstorm/api/v1/webhooks/vadc_hook"
+    type: string
+    required: true
+  name:
+    description: "The name of the Action. Default is st2Action"
+    type: string
+    required: false
+    default: "st2Action"
+  event:
+    description: "The name of an existing Event to attach the Action to"
+    type: string
+    required: false

--- a/actions/vtm_create_backup.py
+++ b/actions/vtm_create_backup.py
@@ -1,0 +1,13 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+
+
+class VtmCreateBackup(Action):
+
+    def run(self, vtm, name, description):
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        vtm.create_backup(name, description)
+        return (True, None)

--- a/actions/vtm_create_backup.yaml
+++ b/actions/vtm_create_backup.yaml
@@ -1,0 +1,19 @@
+description: 'vTM - Create a Configuration Backup'
+enabled: true
+entry_point: vtm_create_backup.py
+name: vtm_create_backup
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure, the tag or instance ID on BSD."
+    type: string
+    required: true
+  name:
+    description: "The name of the Backup"
+    type: string
+    required: true
+  description:
+    description: "An optional description of the backup"
+    required: false
+    type: string
+    default: "StackStorm Backup"

--- a/actions/vtm_del_persistence.py
+++ b/actions/vtm_del_persistence.py
@@ -9,4 +9,5 @@ class VtmDelPersistence(Action):
     def run(self, vtm, name):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.delSessionPersistence(name)
+        vtm.del_session_persistence(name)
+        return (True, None)

--- a/actions/vtm_del_pool.py
+++ b/actions/vtm_del_pool.py
@@ -9,4 +9,5 @@ class VtmDelPool(Action):
     def run(self, vtm, name):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.delPool(name)
+        vtm.del_pool(name)
+        return (True, None)

--- a/actions/vtm_del_server_cert.py
+++ b/actions/vtm_del_server_cert.py
@@ -9,4 +9,5 @@ class VtmDelServerCert(Action):
     def run(self, vtm, name):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.delServerCert(name)
+        vtm.del_server_cert(name)
+        return (True, None)

--- a/actions/vtm_del_tip.py
+++ b/actions/vtm_del_tip.py
@@ -9,4 +9,5 @@ class VtmDelPool(Action):
     def run(self, vtm, name):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.delTip(name)
+        vtm.del_tip(name)
+        return (True, None)

--- a/actions/vtm_del_vserver.py
+++ b/actions/vtm_del_vserver.py
@@ -9,4 +9,5 @@ class VtmDelVserver(Action):
     def run(self, vtm, name):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.delVserver(name)
+        vtm.del_vserver(name)
+        return (True, None)

--- a/actions/vtm_delete_backup.py
+++ b/actions/vtm_delete_backup.py
@@ -1,0 +1,13 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+
+
+class VtmDeleteBackup(Action):
+
+    def run(self, vtm, name):
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        vtm.delete_backup(name)
+        return (True, None)

--- a/actions/vtm_delete_backup.yaml
+++ b/actions/vtm_delete_backup.yaml
@@ -1,0 +1,14 @@
+description: 'vTM - Delete a Configuration Backup'
+enabled: true
+entry_point: vtm_delete_backup.py
+name: vtm_delete_backup
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure, the tag or instance ID on BSD."
+    type: string
+    required: true
+  name:
+    description: "The Backup you wish to restore"
+    type: string
+    required: true

--- a/actions/vtm_disable_ssl_encryption.py
+++ b/actions/vtm_disable_ssl_encryption.py
@@ -9,4 +9,5 @@ class VtmDisableSslEncryption(Action):
     def run(self, vtm, name, verify):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.enableSSLEncryption(name, False, verify)
+        vtm.enable_ssl_encryption(name, False, verify)
+        return (True, None)

--- a/actions/vtm_disable_ssl_offload.py
+++ b/actions/vtm_disable_ssl_offload.py
@@ -9,4 +9,5 @@ class VtmDisableSslOffload(Action):
     def run(self, vtm, name, xproto, headers):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.enableSSLOffload(name, "", False, xproto, headers)
+        vtm.enable_ssl_offload(name, "", False, xproto, headers)
+        return (True, None)

--- a/actions/vtm_drain_nodes.py
+++ b/actions/vtm_drain_nodes.py
@@ -9,4 +9,5 @@ class VtmDrainNodes(Action):
     def run(self, vtm, pool, nodes, drain):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.drainNodes(pool, nodes, drain)
+        vtm.drain_nodes(pool, nodes, drain)
+        return (True, None)

--- a/actions/vtm_enable_ssl_encryption.py
+++ b/actions/vtm_enable_ssl_encryption.py
@@ -9,4 +9,5 @@ class VtmEnableSslEncryption(Action):
     def run(self, vtm, name, verify):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.enableSSLEncryption(name, True, verify)
+        vtm.enable_ssl_encryption(name, True, verify)
+        return (True, None)

--- a/actions/vtm_enable_ssl_offload.py
+++ b/actions/vtm_enable_ssl_offload.py
@@ -9,4 +9,5 @@ class VtmEnableSslOffload(Action):
     def run(self, vtm, name, cert, xproto, headers):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.enableSSLOffload(name, cert, True, xproto, headers)
+        vtm.enable_ssl_offload(name, cert, True, xproto, headers)
+        return (True, None)

--- a/actions/vtm_get_backup.py
+++ b/actions/vtm_get_backup.py
@@ -11,7 +11,7 @@ class VtmGetBackup(Action):
     def run(self, vtm, name, outdir):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        
+
         if path.isdir(outdir) is True:
             outfile = "{}/backup_{}_{}.tar".format(outdir, vtm.vtm, name)
             if path.exists(outfile) is False:

--- a/actions/vtm_get_backup.py
+++ b/actions/vtm_get_backup.py
@@ -1,0 +1,32 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+from os import path
+import sys
+
+
+class VtmGetBackup(Action):
+
+    def run(self, vtm, name, b64, outdir):
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        
+        if outdir is not None:
+            if path.isdir(outdir) is True:
+                outfile = "{}/backup_{}_{}.tar".format(outdir, vtm.vtm, name)
+                if path.exists(outfile) is False:
+                    fh = open(outfile, "wb")
+                    backup = vtm.get_backup(name, False)
+                    fh.write(backup)
+                    fh.close()
+                    return (True, outfile)
+                else:
+                    sys.stderr.write("File exists: {}\n".format(outfile))
+                    return (False, None)
+            else:
+                sys.stderr.write("Outdir is not a directory!\n")
+                return (False, None)
+        else:
+            backup = vtm.get_backup(name, b64)
+            return (True, backup)

--- a/actions/vtm_get_backup.py
+++ b/actions/vtm_get_backup.py
@@ -8,25 +8,21 @@ import sys
 
 class VtmGetBackup(Action):
 
-    def run(self, vtm, name, b64, outdir):
+    def run(self, vtm, name, outdir):
 
         vtm = Vtm(self.config, self.logger, vtm)
         
-        if outdir is not None:
-            if path.isdir(outdir) is True:
-                outfile = "{}/backup_{}_{}.tar".format(outdir, vtm.vtm, name)
-                if path.exists(outfile) is False:
-                    fh = open(outfile, "wb")
-                    backup = vtm.get_backup(name, False)
-                    fh.write(backup)
-                    fh.close()
-                    return (True, outfile)
-                else:
-                    sys.stderr.write("File exists: {}\n".format(outfile))
-                    return (False, None)
+        if path.isdir(outdir) is True:
+            outfile = "{}/backup_{}_{}.tar".format(outdir, vtm.vtm, name)
+            if path.exists(outfile) is False:
+                fh = open(outfile, "wb")
+                backup = vtm.get_backup(name)
+                fh.write(backup)
+                fh.close()
+                return (True, outfile)
             else:
-                sys.stderr.write("Outdir is not a directory!\n")
+                sys.stderr.write("File exists: {}\n".format(outfile))
                 return (False, None)
         else:
-            backup = vtm.get_backup(name, b64)
-            return (True, backup)
+            sys.stderr.write("Outdir is not a directory!\n")
+            return (False, None)

--- a/actions/vtm_get_backup.yaml
+++ b/actions/vtm_get_backup.yaml
@@ -12,12 +12,7 @@ parameters:
     description: "The name of the Backup"
     type: string
     required: true
-  b64:
-    description: "Base64 Encode the tarfile?"
-    type: boolean
-    required: false
-    default: true
   outdir:
     description: "Output directory name"
     type: string
-    required: false
+    required: true

--- a/actions/vtm_get_backup.yaml
+++ b/actions/vtm_get_backup.yaml
@@ -1,0 +1,23 @@
+description: 'vTM - Get/Download a Configuration Backup'
+enabled: true
+entry_point: vtm_get_backup.py
+name: vtm_get_backup
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure, the tag or instance ID on BSD."
+    type: string
+    required: true
+  name:
+    description: "The name of the Backup"
+    type: string
+    required: true
+  b64:
+    description: "Base64 Encode the tarfile?"
+    type: boolean
+    required: false
+    default: true
+  outdir:
+    description: "Output directory name"
+    type: string
+    required: false

--- a/actions/vtm_get_pool_nodes.py
+++ b/actions/vtm_get_pool_nodes.py
@@ -9,5 +9,5 @@ class VtmGetPoolNodes(Action):
     def run(self, vtm, pool):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        result = vtm.getPoolNodes(pool)
-        return result
+        result = vtm.get_pool_nodes(pool)
+        return (True, result)

--- a/actions/vtm_list_backups.py
+++ b/actions/vtm_list_backups.py
@@ -1,0 +1,13 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+
+
+class VtmListBackups(Action):
+
+    def run(self, vtm):
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        backups = vtm.list_backups()
+        return (True, backups)

--- a/actions/vtm_list_backups.yaml
+++ b/actions/vtm_list_backups.yaml
@@ -1,0 +1,10 @@
+description: 'vTM - List Configuration Backups'
+enabled: true
+entry_point: vtm_list_backups.py
+name: vtm_list_backups
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure, the tag or instance ID on BSD."
+    type: string
+    required: true

--- a/actions/vtm_maintenance_mode.py
+++ b/actions/vtm_maintenance_mode.py
@@ -9,4 +9,5 @@ class VtmMaintenanceMode(Action):
     def run(self, vtm, vserver, rule, enable):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        vtm.enableMaintenance(vserver, rule, enable)
+        vtm.enable_maintenance(vserver, rule, enable)
+        return (True, None)

--- a/actions/vtm_restore_backup.py
+++ b/actions/vtm_restore_backup.py
@@ -1,0 +1,13 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+
+
+class VtmRestoreBackup(Action):
+
+    def run(self, vtm, name):
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        output = vtm.restore_backup(name)
+        return (True, output)

--- a/actions/vtm_restore_backup.yaml
+++ b/actions/vtm_restore_backup.yaml
@@ -1,0 +1,14 @@
+description: 'vTM - Restore a Configuration Backup'
+enabled: true
+entry_point: vtm_restore_backup.py
+name: vtm_restore_backup
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure, the tag or instance ID on BSD."
+    type: string
+    required: true
+  name:
+    description: "The Backup you wish to restore"
+    type: string
+    required: true

--- a/actions/vtm_set_pool_nodes.py
+++ b/actions/vtm_set_pool_nodes.py
@@ -9,5 +9,5 @@ class VtmSetPoolNodes(Action):
     def run(self, vtm, pool, active, draining, disabled):
 
         vtm = Vtm(self.config, self.logger, vtm)
-        result = vtm.set_pool_nodes(pool, active, draining, disabled)
+        vtm.set_pool_nodes(pool, active, draining, disabled)
         return (True, None)

--- a/actions/vtm_set_pool_nodes.py
+++ b/actions/vtm_set_pool_nodes.py
@@ -1,0 +1,13 @@
+#! /usr/bin/python
+
+from st2actions.runners.pythonrunner import Action
+from lib.vadc import Vtm
+
+
+class VtmSetPoolNodes(Action):
+
+    def run(self, vtm, pool, active, draining, disabled):
+
+        vtm = Vtm(self.config, self.logger, vtm)
+        result = vtm.set_pool_nodes(pool, active, draining, disabled)
+        return (True, None)

--- a/actions/vtm_set_pool_nodes.yaml
+++ b/actions/vtm_set_pool_nodes.yaml
@@ -1,0 +1,26 @@
+description: 'vTM - Set Nodes in a Pool'
+enabled: true
+entry_point: vtm_set_pool_nodes.py
+name: vtm_set_pool_nodes
+runner_type: "python-script"
+parameters:
+  vtm:
+    description: "The vTM instance to configure"
+    type: string
+    required: true
+  pool:
+    description: "The name of the pool"
+    type: string
+    required: true
+  active:
+    description: "The list of ACTIVE nodes"
+    type: array
+    required: false
+  draining:
+    description: "The list of DRAINING nodes"
+    type: array
+    required: false
+  disabled:
+    description: "The list of DISABLED nodes"
+    type: array
+    required: false

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,18 +1,67 @@
 ---
+brcd_sd_proxy:
+    description: "Configure vTMs via a Brocade Services Director? Set to False if you want to connect directly"
+    type: boolean
+    default: true
+    required: true
 brcd_sd_host:
-  description: "Service Director API EndPoint (eg https://sd1:8100/)"
-  type: string
-  default: "{{user.brcd_sd_host}}"
-  required: true
+    description: "Service Director API EndPoint (eg https://sd1:8100/). Required if brcd_sd_proxy is true"
+    type: string
+    default: "{{system.brcd_sd_host}}"
+    required: false
 brcd_sd_user:
-  description: "Service Director REST User"
-  default: "{{user.brcd_sd_user}}"
-  type: string
-  required: true
+    description: "Service Director REST User. Required if brcd_sd_proxy is true"
+    default: "{{system.brcd_sd_user}}"
+    type: string
+    required: false
 brcd_sd_pass:
-  description: "Service Director REST Password"
-  type: string
-  default: "{{user.brcd_sd_pass}}"
-  secret: true
-  required: true
-
+    description: "Service Director REST Password. Required if brcd_sd_proxy is true"
+    type: string
+    default: "{{system.brcd_sd_pass}}"
+    secret: true
+    required: false
+brcd_vtm_host:
+    description: "vTM API EndPoint (eg https://vtm01:9070/). Required if brcd_sd_proxy is false"
+    type: string
+    default: "{{user.brcd_vtm_host}}"
+    required: false
+brcd_vtm_user:
+    description: "vTM REST User. Required if brcd_sd_proxy is false"
+    default: "{{user.brcd_vtm_user}}"
+    type: string
+    required: false
+brcd_vtm_pass:
+    description: "vTM REST Password. Required if brcd_sd_proxy is false"
+    type: string
+    default: "{{user.brcd_vtm_pass}}"
+    secret: true
+    required: false
+brcd_bw_manage:
+    description: "Brocade Bandwidth Sensor: Set to 'all' or a list of vTMs which should have their bandwdith automatically assigned."
+    type: string
+    required: false
+brcd_bw_track:
+    description: "Brocade Bandwidth Sensor: How many sensor measurements to track?"
+    default: "10"
+    type: string
+    required: false
+brcd_bw_minimum:
+    description: "Brocade Bandwidth Sensor: The minimum amount of bandwidth to assign to a vTM"
+    default: "10"
+    type: string
+    required: false
+brcd_bw_headroom:
+    description: "Brocade Bandwidth Sensor: How much bandwidth headroom should a vTM maintain?"
+    default: "10"
+    type: string
+    required: false
+brcd_bw_roundup:
+    description: "Brocade Bandwidth Sensor: Roundup bw to nearest n Mb"
+    default: "10"
+    type: string
+    required: false
+brcd_bw_warn:
+    description: "Brocade Bandwidth Sensor: Warning threshold for non-managed vTMs"
+    default: "10"
+    type: string
+    required: false

--- a/files/st2-trigger.py
+++ b/files/st2-trigger.py
@@ -4,6 +4,7 @@ import requests
 import sys
 import json
 
+
 def main():
 
     apiHook = apiKey = None
@@ -26,7 +27,7 @@ def main():
     trigger = details[2] if len(details) >= 3 else ""
     message = details[3] if len(details) >= 4 else ""
 
-    payload = { "event": event, "level": level, "config": config } 
+    payload = {"event": event, "level": level, "config": config}
 
     if "/" in trigger:
         payload["additional"] = trigger
@@ -40,8 +41,7 @@ def main():
 
     print "St2 Payload: {}".format(payload)
 
-    uri="https://stackstorm/api/v1/webhooks/vadc_hook"
-    headers = { "St2-Api-Key": apiKey, "Content-Type": "application/json" }
+    headers = {"St2-Api-Key": apiKey, "Content-Type": "application/json"}
     res = requests.post(apiHook, headers=headers, data=json.dumps(payload), verify=False)
     print "(St2 Response: {}: {}".format(res.status_code, res.text)
 

--- a/files/st2-trigger.py
+++ b/files/st2-trigger.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+
+import requests
+import sys
+import json
+
+def main():
+
+    apiHook = apiKey = None
+    for arg in sys.argv:
+        if arg.startswith("--eventtype="):
+            event = arg[len("--eventtype="):]
+        elif arg.startswith("--api-key="):
+            apiKey = arg[len("--api-key="):]
+        elif arg.startswith("--api-hook="):
+            apiHook = arg[len("--api-hook="):]
+        else:
+            details = arg.split("\t", 3)
+
+    if apiHook is None or apiKey is None:
+        sys.stderr.write("You must provide --api-key and --api-hook arguments")
+        sys.exit(1)
+
+    level = details[0]
+    config = details[1] if len(details) >= 2 else ""
+    trigger = details[2] if len(details) >= 3 else ""
+    message = details[3] if len(details) >= 4 else ""
+
+    payload = { "event": event, "level": level, "config": config } 
+
+    if "/" in trigger:
+        payload["additional"] = trigger
+        extra = message.split("\t", 1)
+        if len(extra) == 2:
+            trigger = extra[0]
+            message = extra[1]
+
+    payload["trigger"] = trigger
+    payload["message"] = message
+
+    print "St2 Payload: {}".format(payload)
+
+    uri="https://stackstorm/api/v1/webhooks/vadc_hook"
+    headers = { "St2-Api-Key": apiKey, "Content-Type": "application/json" }
+    res = requests.post(apiHook, headers=headers, data=json.dumps(payload), verify=False)
+    print "(St2 Response: {}: {}".format(res.status_code, res.text)
+
+if __name__ == "__main__":
+    main()

--- a/rules/bsd_bandwidth_notify.yaml
+++ b/rules/bsd_bandwidth_notify.yaml
@@ -1,7 +1,7 @@
 ---
     name: "bsd_bandwidth_notify"
     pack: "vadc"
-    description: "Realtime Bandwidth Alerts for BSD"
+    description: "Notify ChatOps of a Bandwidth Update"
     enabled: false
 
     trigger:

--- a/rules/vadc_webhook.yaml
+++ b/rules/vadc_webhook.yaml
@@ -1,0 +1,15 @@
+---
+name: "webhook"
+pack: "vadc"
+description: "Example vADC Web Hook Rule."
+enabled: false
+
+trigger:
+        type: "core.st2.webhook"
+        parameters:
+            url: "vadc_hook"
+
+action:
+    ref: "core.local"
+    parameters:
+        cmd: "logger {{trigger.body}}"

--- a/sensors/brcd_bw_sensor.py
+++ b/sensors/brcd_bw_sensor.py
@@ -75,6 +75,9 @@ class brcdBwSensor(PollingSensor):
             else:
                 if instance in bw_tracker:
                     bw_tracker.pop(instance)
+        for instance in bw_tracker.keys():
+            if instance not in bandwidth:
+                bw_tracker.pop(instance)
 
     def _issue_update(self, instance, tracked, instData, bw_tracker, bandwidth):
             average = sum(bw_tracker[instance]["tracking"]) / len(bw_tracker[instance]["tracking"])

--- a/sensors/brcd_bw_sensor.py
+++ b/sensors/brcd_bw_sensor.py
@@ -26,7 +26,7 @@ class brcdBwSensor(PollingSensor):
 
     def poll(self):
         self._get_configs()
-        bandwidth = self._bsd.getBandwidth()
+        bandwidth = self._bsd.get_bandwidth()
         bw_tracker = self._get_bw_tracker()
         if self._manage is not None:
             self._manage_bandwidth(bw_tracker, bandwidth)

--- a/sensors/brcd_sd_sensor.py
+++ b/sensors/brcd_sd_sensor.py
@@ -19,7 +19,7 @@ class brcdSdSensor(PollingSensor):
 
     def poll(self):
         try:
-            errors = self._bsd.getErrors()
+            errors = self._bsd.get_errors()
             last_errors = self._get_last_errors()
             self._set_last_errors(errors)
             self._process_changes(errors, last_errors)

--- a/sensors/brcd_sd_sensor.yaml
+++ b/sensors/brcd_sd_sensor.yaml
@@ -3,6 +3,7 @@ class_name: "brcdSdSensor"
 entry_point: "brcd_sd_sensor.py"
 description: "Brocade Service Director Sensor"
 poll_interval: 30
+enabled: false
 trigger_types:
   -
     name: "bsd_failure_event"


### PR DESCRIPTION
- vtm_add_pool now only sets nodes, unless you provide the optional params for algorithm, monitors, and session persistence.

- You can now parse JSON or YAML strings in an extra parameter to apply addition configuration when creating objects. This can be used with:
   vtm_add_pool
   vtm_add_vserver
   vtm_add_tip

- New action to locate a running vTM when provided with a list of vTMs or a Cluster ID.

- Example vADC webhook rule included, and a python script for calling the hook from the vTM Alerting framework. Script: files/st2-trigger.py

- New Action to upload webhook: vadc.vtm_add_webhook_action

- Added support for vTMs as old as 9.3. Services Director will try universal license and fall back to Legacy FLA

- Added support for list/create/restore/delete backups on vTM 11.0 and above. Restore requires Services Director 2.6, if you are proxying.

- We now detect the latest version of the API available on the BSD/VTM and use it.

